### PR TITLE
feat: add Enhancing Cross-Platform Compatibility

### DIFF
--- a/submodules/moragents_dockers/agents/src/config.py
+++ b/submodules/moragents_dockers/agents/src/config.py
@@ -11,7 +11,7 @@ class Config:
     # Model configuration
     OLLAMA_MODEL = "llama3.2:3b"
     OLLAMA_EMBEDDING_MODEL = "nomic-embed-text"
-    OLLAMA_URL = "http://host.docker.internal:11434"
+    OLLAMA_URL = "http://ollama:11434"
 
     MAX_UPLOAD_LENGTH = 16 * 1024 * 1024
     AGENTS_CONFIG = {

--- a/submodules/moragents_dockers/docker-compose.yml
+++ b/submodules/moragents_dockers/docker-compose.yml
@@ -1,5 +1,4 @@
 version: "3.8"
-
 services:
   agents:
     image: lachsbagel/moragents_dockers-agents:amd64-0.2.2
@@ -12,10 +11,10 @@ services:
     volumes:
       - agents_data:/var/lib/agents
       - ./agents/src:/app/src
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
     environment:
-      - BASE_URL=http://host.docker.internal:11434
+      - BASE_URL=http://ollama:11434
+    networks:
+      - ollama-network
 
   nginx:
     image: lachsbagel/moragents_dockers-nginx:amd64-0.2.2
@@ -25,6 +24,22 @@ services:
       target: nginx
     ports:
       - "3333:80"
+    networks:
+      - ollama-network
+
+  ollama:
+    image: ollama/ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    networks:
+      - ollama-network
+
+networks:
+  ollama-network:
+    driver: bridge
 
 volumes:
   agents_data:
+  ollama_data:

--- a/submodules/moragents_dockers/ollama/Dockerfile
+++ b/submodules/moragents_dockers/ollama/Dockerfile
@@ -1,0 +1,6 @@
+FROM ollama/ollama:latest
+
+# Install curl for healthcheck
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+
+EXPOSE 11434    


### PR DESCRIPTION
This pull request includes several changes to the configuration and setup of the `moragents_dockers` submodule. The changes primarily focus on updating the service URLs and adding a new `ollama` service to the Docker setup.

Configuration updates:

* [`submodules/moragents_dockers/agents/src/config.py`](diffhunk://#diff-21fc88b7715f3623c3b6acdb0333931eb1d7a70a3351c910fd7fcc467d717947L14-R14): Updated the `OLLAMA_URL` to use `http://ollama:11434` instead of `http://host.docker.internal:11434`.

Docker setup changes:

* [`submodules/moragents_dockers/docker-compose.yml`](diffhunk://#diff-86b1c564dd7d8e254d41f9ceb5be535bd1b144a3d17e93c4c6eb7159f849d7b4L15-R17): Removed the `extra_hosts` configuration and updated the `BASE_URL` environment variable to use `http://ollama:11434`. Added a new `ollama` service with its own network and volume. [[1]](diffhunk://#diff-86b1c564dd7d8e254d41f9ceb5be535bd1b144a3d17e93c4c6eb7159f849d7b4L15-R17) [[2]](diffhunk://#diff-86b1c564dd7d8e254d41f9ceb5be535bd1b144a3d17e93c4c6eb7159f849d7b4R27-R45)
* [`submodules/moragents_dockers/ollama/Dockerfile`](diffhunk://#diff-57f29674a8fa20c994c2ada9c64c41bdc1ba45aca3a95b58561d926e4791e198R1-R6): Added a new Dockerfile for the `ollama` service, including installation of `curl` for health checks and exposing port `11434`.

Testing Considerations:

The update has been tested and runs successfully on both Linux and Windows environments. No issues were encountered during testing, and the service configurations work as expected.

    Linux: Verified that the new ollama service starts correctly, and the updated OLLAMA_URL works as intended.
    Windows: Ensured that removing extra_hosts does not impact connectivity and that the Docker setup functions properly.
    macOS: While not explicitly tested, there is no known reason for it not to work, as the changes are platform-agnostic and rely on standard Docker networking.